### PR TITLE
fix v6 loopback address

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -7,7 +7,7 @@ docker-compose up -d
 cp config.toml.template config.toml
 cargo run
 ```
-This let's the server listen on `[::1]:3779` and allows CORS-Request from any localhost origin.
+This let's the server listen on `[::]:3779` and allows CORS-Request from any localhost origin.
 If you want to properly deploy to production you probably want to disallow CORS-Request from localhost
 and allow the origins of your frontend deployment and configure your redis + postgresql URL using the config.toml.
 

--- a/api/README.md
+++ b/api/README.md
@@ -7,7 +7,7 @@ docker-compose up -d
 cp config.toml.template config.toml
 cargo run
 ```
-This let's the server listen on `[::0]:3779` and allows CORS-Request from any localhost origin.
+This let's the server listen on `[::1]:3779` and allows CORS-Request from any localhost origin.
 If you want to properly deploy to production you probably want to disallow CORS-Request from localhost
 and allow the origins of your frontend deployment and configure your redis + postgresql URL using the config.toml.
 


### PR DESCRIPTION
Following [RFC 1884](https://www.rfc-editor.org/rfc/rfc1884), `0:0:0:0:0:0:0:0` is correctly abbreviated by `::`, not by `::0`.